### PR TITLE
Allow Loading Pre-trained models in pure python (no roscore), with vanilla stable-baselines (not forked)

### DIFF
--- a/rl_agent/src/rl_agent/common_custom_policies.py
+++ b/rl_agent/src/rl_agent/common_custom_policies.py
@@ -13,6 +13,79 @@ import numpy as np
 
 NS="sim1"
 
+def ortho_init(scale=1.0):
+    """
+    Orthogonal initialization for the policy weights
+    :param scale: (float) Scaling factor for the weights.
+    :return: (function) an initialization function for the weights
+    """
+
+    # _ortho_init(shape, dtype, partition_info=None)
+    def _ortho_init(shape, *_, **_kwargs):
+        """Intialize weights as Orthogonal matrix.
+        Orthogonal matrix initialization [1]_. For n-dimensional shapes where
+        n > 2, the n-1 trailing axes are flattened. For convolutional layers, this
+        corresponds to the fan-in, so this makes the initialization usable for
+        both dense and convolutional layers.
+        References
+        ----------
+        .. [1] Saxe, Andrew M., James L. McClelland, and Surya Ganguli.
+               "Exact solutions to the nonlinear dynamics of learning in deep
+               linear
+        """
+        # lasagne ortho init for tf
+        shape = tuple(shape)
+        if len(shape) == 2:
+            flat_shape = shape
+        elif len(shape) == 4:  # assumes NHWC
+            flat_shape = (np.prod(shape[:-1]), shape[-1])
+        # Added by Ronja
+        elif len(shape) == 3:  # assumes NWC
+            flat_shape = (np.prod(shape[:-1]), shape[-1])
+        else:
+            raise NotImplementedError
+        gaussian_noise = np.random.normal(0.0, 1.0, flat_shape)
+        u, _, v = np.linalg.svd(gaussian_noise, full_matrices=False)
+        weights = u if u.shape == flat_shape else v  # pick the one with the correct shape
+        weights = weights.reshape(shape)
+        return (scale * weights[:shape[0], :shape[1]]).astype(np.float32)
+
+    return _ortho_init
+
+# Added by Ronja Gueldenring
+def conv1d(input_tensor, scope, *, n_filters, filter_size, stride,
+         pad='VALID', init_scale=1.0, data_format='NWC', one_dim_bias=False):
+    """
+    Creates a 1d convolutional layer for TensorFlow
+    :param input_tensor: (TensorFlow Tensor) The input tensor for the convolution
+    :param scope: (str) The TensorFlow variable scope
+    :param n_filters: (int) The number of filters
+    :param filter_size: (int) The filter size
+    :param stride: (int) The stride of the convolution
+    :param pad: (str) The padding type ('VALID' or 'SAME')
+    :param init_scale: (int) The initialization scale
+    :param data_format: (str) The data format for the convolution weights
+    :param one_dim_bias: (bool) If the bias should be one dimentional or not
+    :return: (TensorFlow Tensor) 2d convolutional layer
+    """
+    if data_format == 'NWC':
+        channel_ax = 2
+        bshape = [1, 1, n_filters]
+    elif data_format == 'NCW':
+        channel_ax = 0
+        bshape = [1, n_filters, 1]
+    else:
+        raise NotImplementedError
+
+    bias_var_shape = [n_filters] if one_dim_bias else [1, n_filters, 1]
+    n_input = input_tensor.get_shape()[channel_ax].value
+    wshape = [filter_size, n_input, n_filters]
+    with tf.variable_scope(scope):
+        weight = tf.get_variable("w", wshape, initializer=ortho_init(init_scale))
+        bias = tf.get_variable("b", bias_var_shape, initializer=tf.constant_initializer(0.0))
+        if not one_dim_bias and data_format == 'NWC':
+            bias = tf.reshape(bias, bshape)
+        return bias + tf.nn.conv1d(input_tensor, weight, stride=stride, padding=pad, data_format=data_format)
 
 ######################################
 ###### CNN1DPolicy_multi_input #######
@@ -48,7 +121,10 @@ class CNN1DPolicy_multi_input(common.FeedForwardPolicy):
     This class provides a 1D convolutional network for the Raw Data Representation
     """
     def __init__(self, *args, **kwargs):
-        kwargs["laser_scan_len"] = rospy.get_param("%s/rl_agent/scan_size"%NS, 360)
+        try:
+            kwargs["laser_scan_len"] = rospy.get_param("%s/rl_agent/scan_size"%NS, 90)
+        except ConnectionRefusedError:
+            kwargs["laser_scan_len"] = 90
         super(CNN1DPolicy_multi_input, self).__init__(*args, **kwargs, cnn_extractor=laser_cnn_multi_input, feature_extraction="cnn")
 
 

--- a/rl_agent/src/rl_agent/common_custom_policies.py
+++ b/rl_agent/src/rl_agent/common_custom_policies.py
@@ -125,6 +125,8 @@ class CNN1DPolicy_multi_input(common.FeedForwardPolicy):
             kwargs["laser_scan_len"] = rospy.get_param("%s/rl_agent/scan_size"%NS, 90)
         except ConnectionRefusedError:
             kwargs["laser_scan_len"] = 90
+        except AttributeError:
+            kwargs["laser_scan_len"] = 90
         super(CNN1DPolicy_multi_input, self).__init__(*args, **kwargs, cnn_extractor=laser_cnn_multi_input, feature_extraction="cnn")
 
 


### PR DESCRIPTION
Hi @RGring , very interesting work! To allow the community to use your pre-trained models, it can be helpful to be able to load them without ROS, and using the main stable-baselines distribution. This PR attempts to do just that, and being small, it should not introduce any bugs.

The one thing I'm worried about, is that the conv1d layer function added to common_custom_policies module overshadows the declaration in your stable-baselines fork. It should not cause any issues, but could cause confusion in the future. I let you decide if/how you'd like to handle this. 

Feel free to reject this PR if it does not LGTY!